### PR TITLE
add fee mechanism

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,7 +22,10 @@ dependencies = [
  "k256",
  "prost",
  "rand",
+ "serde",
  "sg-metadata",
+ "sg-std",
+ "sg1",
  "sg721",
  "sha2 0.10.2",
  "thiserror",
@@ -751,6 +754,19 @@ dependencies = [
  "cw721-base",
  "schemars",
  "serde",
+ "thiserror",
+]
+
+[[package]]
+name = "sg1"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c38c43f055f8807ffce245f067684a65f841d7117bdda862f257291fb29ec4c1"
+dependencies = [
+ "cosmwasm-std",
+ "cw-utils",
+ "serde",
+ "sg-std",
  "thiserror",
 ]
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The Badges project consists of two smart contracts:
 
 ### Minting
 
-Creation of new badges is permissionless. There currently isn't a creation fee, but one can be added later.
+Creation of new badges is permissionless. When creating a new badge, a fee is charged based on the amount of storage space it consumes. The fee rate, defined as ustars per byte, can be set by L1 governance.
 
 Each badge defines its own minting rule. There are three such rules to be chosen from:
 

--- a/contracts/hub/Cargo.toml
+++ b/contracts/hub/Cargo.toml
@@ -20,14 +20,17 @@ library = []
 [dependencies]
 badges = { path = "../../packages/badges" }
 cosmwasm-std = "1.0"
-cw-item-set = "0.4.0"
+cw-item-set = "0.4"
 cw-storage-plus = "0.13"
 cw-utils = "0.13"
 cw2 = "0.13"
 hex = "0.4"
+serde = { version = "1.0", default-features = false }
+sg1 = "0.14"
 sg721 = "0.14"
 # TODO: update once published on crates.io
 sg-metadata = { git = "https://github.com/public-awesome/launchpad", rev = "c5280ef" }
+sg-std = "0.14"
 sha2 = "0.10"
 thiserror = "1"
 

--- a/contracts/hub/src/error.rs
+++ b/contracts/hub/src/error.rs
@@ -15,6 +15,9 @@ pub enum ContractError {
     ParseReply(#[from] cw_utils::ParseReplyError),
 
     #[error("{0}")]
+    Fee(#[from] sg1::FeeError),
+
+    #[error("{0}")]
     Verification(#[from] VerificationError),
 
     #[error("invalid reply id {0}; must be 1")]

--- a/contracts/hub/src/fee.rs
+++ b/contracts/hub/src/fee.rs
@@ -1,0 +1,33 @@
+use cosmwasm_std::{to_binary, MessageInfo, Storage, Uint128};
+use sg_std::Response;
+
+use crate::error::ContractError;
+use crate::state::{DEVELOPER, FEE_PER_BYTE};
+
+// TODO: add docs
+pub fn handle_fee<T: serde::Serialize>(
+    store: &dyn Storage,
+    info: &MessageInfo,
+    old_data: Option<T>,
+    new_data: T,
+) -> Result<Response, ContractError> {
+    let old_bytes = old_data
+        .map(|data| to_binary(&data))
+        .transpose()?
+        .map(|bytes| bytes.len())
+        .unwrap_or(0);
+    let new_bytes = to_binary(&new_data)?.len();
+    let bytes_diff = new_bytes.saturating_sub(old_bytes);
+
+    let fee_per_bytes = FEE_PER_BYTE.load(store)?;
+    let fee = Uint128::new(bytes_diff as u128) * fee_per_bytes;
+
+    let mut res = Response::new();
+
+    if !fee.is_zero() {
+        let developer = DEVELOPER.load(store)?;
+        sg1::checked_fair_burn(info, fee.u128(), Some(developer), &mut res)?;
+    }
+
+    Ok(res)
+}

--- a/contracts/hub/src/helpers.rs
+++ b/contracts/hub/src/helpers.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 
-use cosmwasm_std::{Addr, Api, BlockInfo, Deps, Storage};
+use cosmwasm_std::{Addr, Api, BlockInfo, Deps, Storage, Coin};
 use sha2::{Digest, Sha256};
 
 use badges::{Badge, MintRule};
@@ -29,6 +29,15 @@ pub fn hash(msg: &str) -> Vec<u8> {
 /// A helper function to help casting Option to String
 pub fn stringify_option(opt: Option<impl fmt::Display>) -> String {
     opt.map_or_else(|| "undefined".to_string(), |value| value.to_string())
+}
+
+/// Casting Vec<Coin> to a string
+pub fn stringify_funds(funds: &[Coin]) -> String {
+    funds
+        .iter()
+        .map(|coin| coin.to_string())
+        .collect::<Vec<_>>()
+        .join(",")
 }
 
 /// This is basically a wrapper of `api.secp256k1_verify`, but instead of taking raw bytes in the

--- a/contracts/hub/src/lib.rs
+++ b/contracts/hub/src/lib.rs
@@ -1,15 +1,17 @@
 pub mod contract;
 pub mod error;
+pub mod fee;
 pub mod helpers;
 pub mod state;
 
 #[cfg(not(feature = "library"))]
 pub mod entry {
     use cosmwasm_std::{
-        entry_point, to_binary, Binary, Deps, DepsMut, Env, MessageInfo, Reply, Response, StdResult,
+        entry_point, to_binary, Binary, Deps, DepsMut, Env, MessageInfo, Reply, StdResult,
     };
+    use sg_std::Response;
 
-    use badges::hub::{ExecuteMsg, InstantiateMsg, QueryMsg};
+    use badges::hub::{ExecuteMsg, InstantiateMsg, QueryMsg, SudoMsg};
 
     use crate::contract;
     use crate::error::ContractError;
@@ -21,7 +23,14 @@ pub mod entry {
         info: MessageInfo,
         msg: InstantiateMsg,
     ) -> StdResult<Response> {
-        contract::init(deps, env, info, msg.nft_code_id, msg.nft_info)
+        contract::init(
+            deps,
+            env,
+            info,
+            msg.nft_code_id,
+            msg.nft_info,
+            msg.fee_per_byte,
+        )
     }
 
     #[entry_point]
@@ -29,6 +38,15 @@ pub mod entry {
         match reply.id {
             1 => contract::init_hook(deps, reply),
             id => Err(ContractError::InvalidReplyId(id)),
+        }
+    }
+
+    #[entry_point]
+    pub fn sudo(deps: DepsMut, _env: Env, msg: SudoMsg) -> StdResult<Response> {
+        match msg {
+            SudoMsg::SetFeeRate {
+                fee_per_byte,
+            } => contract::set_fee_rate(deps, fee_per_byte),
         }
     }
 
@@ -47,11 +65,21 @@ pub mod entry {
                 rule,
                 expiry,
                 max_supply,
-            } => contract::create_badge(deps, env, manager, metadata, transferrable, rule, expiry, max_supply),
+            } => contract::create_badge(
+                deps,
+                env,
+                info,
+                manager,
+                metadata,
+                transferrable,
+                rule,
+                expiry,
+                max_supply,
+            ),
             ExecuteMsg::EditBadge {
                 id,
                 metadata,
-            } => contract::edit_badge(deps, info.sender, id, metadata),
+            } => contract::edit_badge(deps, info, id, metadata),
             ExecuteMsg::AddKeys {
                 id,
                 keys,

--- a/contracts/hub/src/state.rs
+++ b/contracts/hub/src/state.rs
@@ -1,11 +1,17 @@
-use cosmwasm_std::Addr;
+use cosmwasm_std::{Addr, Decimal};
 use cw_item_set::Set;
 use cw_storage_plus::{Item, Map};
 
 use badges::Badge;
 
+/// Address of the developer
+pub const DEVELOPER: Item<Addr> = Item::new("owner");
+
 /// Address of badge nft contract
 pub const NFT: Item<Addr> = Item::new("nft");
+
+/// The fee rate, in ustars per byte, charged for when creating or editing badges
+pub const FEE_PER_BYTE: Item<Decimal> = Item::new("fee_per_byte");
 
 /// Total number of badges
 pub const BADGE_COUNT: Item<u64> = Item::new("badge_count");

--- a/contracts/hub/tests/deployment.rs
+++ b/contracts/hub/tests/deployment.rs
@@ -1,6 +1,6 @@
 use cosmwasm_std::testing::{mock_dependencies, mock_env, mock_info, MOCK_CONTRACT_ADDR};
 use cosmwasm_std::{
-    attr, to_binary, Addr, Empty, Reply, SubMsg, SubMsgResponse, SubMsgResult, WasmMsg,
+    attr, to_binary, Addr, Decimal, Empty, Reply, SubMsg, SubMsgResponse, SubMsgResult, WasmMsg,
 };
 use prost::Message;
 use sg721::CollectionInfo;
@@ -27,6 +27,7 @@ fn instantiating() {
         mock_info("larry", &[]),
         168,
         collection_info.clone(),
+        Decimal::from_ratio(10u128, 1u128),
     )
     .unwrap();
     assert_eq!(

--- a/contracts/hub/tests/fee.rs
+++ b/contracts/hub/tests/fee.rs
@@ -1,0 +1,284 @@
+use std::collections::BTreeSet;
+
+use cosmwasm_std::testing::{mock_dependencies, mock_info, MockApi, MockQuerier, MockStorage};
+use cosmwasm_std::{
+    coins, to_binary, Addr, BankMsg, Decimal, DepsMut, Empty, Event, OwnedDeps, SubMsg, Uint128,
+};
+use cw_utils::PaymentError;
+use k256::ecdsa::VerifyingKey;
+use sg1::FeeError;
+use sg_metadata::{Metadata, Trait};
+use sg_std::{create_fund_fairburn_pool_msg, Response, NATIVE_DENOM};
+
+use badge_hub::contract::{self, add_keys};
+use badge_hub::error::ContractError;
+use badge_hub::state::*;
+use badges::{Badge, MintRule};
+
+mod utils;
+
+// 10 ustars per bytes
+fn mock_fee_per_byte() -> Decimal {
+    Decimal::from_ratio(10u128, 1u128)
+}
+
+fn setup_test() -> OwnedDeps<MockStorage, MockApi, MockQuerier, Empty> {
+    let mut deps = mock_dependencies();
+
+    DEVELOPER.save(deps.as_mut().storage, &Addr::unchecked("larry")).unwrap();
+    NFT.save(deps.as_mut().storage, &Addr::unchecked("nft")).unwrap();
+    BADGE_COUNT.save(deps.as_mut().storage, &0).unwrap();
+    FEE_PER_BYTE.save(deps.as_mut().storage, &mock_fee_per_byte()).unwrap();
+
+    deps
+}
+
+fn assert_correct_sg1_output(res: &Response, fee_amount: u128) {
+    let dev_amount = fee_amount * 10 / 100;
+    let burn_amount = fee_amount * 40 / 100;
+    let dist_amount = fee_amount - dev_amount - burn_amount;
+
+    assert_eq!(
+        res.messages,
+        vec![
+            SubMsg::new(BankMsg::Send {
+                to_address: "larry".to_string(),
+                amount: coins(dev_amount, NATIVE_DENOM),
+            }),
+            SubMsg::new(BankMsg::Burn {
+                amount: coins(burn_amount, NATIVE_DENOM),
+            }),
+            SubMsg::new(create_fund_fairburn_pool_msg(coins(dist_amount, NATIVE_DENOM)))
+        ]
+    );
+    assert_eq!(
+        res.events,
+        vec![Event::new("fair-burn")
+            .add_attribute("dev", "larry")
+            .add_attribute("dev_amount", dev_amount.to_string())
+            .add_attribute("burn_amount", burn_amount.to_string())
+            .add_attribute("dist_amount", dist_amount.to_string())]
+    );
+}
+
+#[test]
+fn badge_creation_fee() {
+    let mut deps = setup_test();
+
+    let mock_badge = Badge {
+        id: 1,
+        manager: Addr::unchecked("manager"),
+        metadata: Metadata::default(),
+        transferrable: false,
+        rule: MintRule::ByKeys,
+        expiry: None,
+        max_supply: None,
+        current_supply: 0,
+    };
+
+    let mut create = |amount: u128, denom: &str| -> Result<Response, ContractError> {
+        contract::create_badge(
+            deps.as_mut(),
+            utils::mock_env_at_timestamp(10000),
+            mock_info("creator", &coins(amount, denom)),
+            mock_badge.manager.clone().into(),
+            mock_badge.metadata.clone(),
+            mock_badge.transferrable,
+            mock_badge.rule.clone(),
+            mock_badge.expiry,
+            mock_badge.max_supply,
+        )
+    };
+
+    let bytes = to_binary(&mock_badge).unwrap();
+    let fee_amount = (Uint128::from(bytes.len() as u128) * mock_fee_per_byte()).u128();
+
+    // try create without sending a fee, should fail
+    {
+        let err = create(0, NATIVE_DENOM).unwrap_err();
+        assert_eq!(err, FeeError::from(PaymentError::NoFunds {}).into());
+    }
+
+    // try create with less than sufficient amount, should fail
+    {
+        let insufficient_amount = fee_amount * 9 / 10;
+
+        let err = create(insufficient_amount, NATIVE_DENOM).unwrap_err();
+        assert_eq!(err, FeeError::InsufficientFee(fee_amount, insufficient_amount).into());
+    }
+
+    // try create with correct amount but wrong denom, should fail
+    {
+        let err = create(fee_amount, "doge").unwrap_err();
+        assert_eq!(
+            err,
+            FeeError::from(PaymentError::MissingDenom(NATIVE_DENOM.to_string())).into()
+        );
+    }
+
+    // try create with correct amount and denom, should succeed
+    {
+        let res = create(fee_amount, NATIVE_DENOM).unwrap();
+        assert_correct_sg1_output(&res, fee_amount);
+    }
+}
+
+#[test]
+fn badge_editing_fee() {
+    let mut deps = setup_test();
+
+    let old_metadata = Metadata {
+        name: Some("skyrim".to_string()),
+        attributes: Some(vec![
+            Trait {
+                display_type: None,
+                trait_type: "high_king".to_string(),
+                value: "torygg".to_string(),
+            },
+            Trait {
+                display_type: None,
+                trait_type: "capital".to_string(),
+                value: "solitude".to_string(),
+            },
+        ]),
+        ..Default::default()
+    };
+
+    let new_metadata = Metadata {
+        name: Some("skyrim".to_string()),
+        attributes: Some(vec![
+            Trait {
+                display_type: None,
+                trait_type: "high_king".to_string(),
+                value: "ulfric_stormcloak".to_string(),
+            },
+            Trait {
+                display_type: None,
+                trait_type: "capital".to_string(),
+                value: "windhelm".to_string(),
+            },
+        ]),
+        ..Default::default()
+    };
+
+    let mock_badge = Badge {
+        id: 1,
+        manager: Addr::unchecked("manager"),
+        metadata: old_metadata.clone(),
+        transferrable: false,
+        rule: MintRule::ByKeys,
+        expiry: None,
+        max_supply: None,
+        current_supply: 0,
+    };
+
+    BADGES.save(deps.as_mut().storage, 1, &mock_badge).unwrap();
+
+    // can't use closure here due to borrowing
+    fn edit(deps: DepsMut, metadata: &Metadata, amount: u128) -> Result<Response, ContractError> {
+        contract::edit_badge(
+            deps,
+            mock_info("manager", &coins(amount, NATIVE_DENOM)),
+            1,
+            metadata.clone(),
+        )
+    }
+
+    // if data size is smaller, no fee should be charged
+    {
+        let metadata = Metadata::default();
+
+        let res = edit(deps.as_mut(), &metadata, 0).unwrap();
+        assert_eq!(res.messages, vec![]);
+
+        let badge = BADGES.load(deps.as_ref().storage, 1).unwrap();
+        assert_eq!(badge.metadata, metadata);
+    }
+
+    // reset badge
+    BADGES.save(deps.as_mut().storage, 1, &mock_badge).unwrap();
+
+    // calculate the expected fee amount
+    let old_bytes = to_binary(&old_metadata).unwrap().len() as u128;
+    let new_bytes = to_binary(&new_metadata).unwrap().len() as u128;
+    let fee_amount = (Uint128::new(new_bytes - old_bytes) * mock_fee_per_byte()).u128();
+
+    // not sending sufficient fee, should fail
+    {
+        let insufficient_amount = fee_amount * 9 / 10;
+
+        let err = edit(deps.as_mut(), &new_metadata, insufficient_amount).unwrap_err();
+        assert_eq!(err, FeeError::InsufficientFee(fee_amount, insufficient_amount).into());
+    }
+
+    // send sufficient fee, should succeed
+    {
+        let res = edit(deps.as_mut(), &new_metadata, fee_amount).unwrap();
+        assert_correct_sg1_output(&res, fee_amount);
+    }
+}
+
+#[test]
+fn key_adding_fee() {
+    let mut deps = setup_test();
+
+    let mock_badge = Badge {
+        id: 1,
+        manager: Addr::unchecked("manager"),
+        metadata: Metadata::default(),
+        transferrable: false,
+        rule: MintRule::ByKeys,
+        expiry: None,
+        max_supply: None,
+        current_supply: 0,
+    };
+
+    BADGES.save(deps.as_mut().storage, 1, &mock_badge).unwrap();
+
+    let mock_keys = (1..20)
+        .map(|_| {
+            let privkey = utils::random_privkey();
+            let pubkey = VerifyingKey::from(&privkey);
+            hex::encode(pubkey.to_bytes())
+        })
+        .collect::<Vec<_>>();
+
+    let mock_keys_set = mock_keys
+        .iter()
+        .cloned()
+        .collect::<BTreeSet<_>>();
+
+    let bytes = to_binary(&mock_keys).unwrap().len() as u128;
+    let fee_amount = (Uint128::new(bytes) * mock_fee_per_byte()).u128();
+
+    fn add(
+        deps: DepsMut,
+        keys: &BTreeSet<String>,
+        amount: u128,
+    ) -> Result<Response, ContractError> {
+        add_keys(
+            deps,
+            utils::mock_env_at_timestamp(10000),
+            mock_info("manager", &coins(amount, NATIVE_DENOM)),
+            1,
+            keys.clone(),
+        )
+    }
+
+    // not sending sufficient fee
+    {
+        let insufficient_amount = fee_amount * 9 / 10;
+
+        let err = add(deps.as_mut(), &mock_keys_set, insufficient_amount).unwrap_err();
+        assert_eq!(err, FeeError::InsufficientFee(fee_amount, insufficient_amount).into());
+    }
+
+    // sending sufficient fee
+    {
+        let res = add(deps.as_mut(), &mock_keys_set, fee_amount).unwrap();
+        assert_correct_sg1_output(&res, fee_amount);
+
+        let whitelisted = contract::query_key(deps.as_ref(), 1, &mock_keys[7]);
+        assert!(whitelisted);
+    }
+}

--- a/packages/badges/src/hub.rs
+++ b/packages/badges/src/hub.rs
@@ -1,5 +1,6 @@
 use std::collections::BTreeSet;
 
+use cosmwasm_std::Decimal;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use sg721::{CollectionInfo, RoyaltyInfoResponse};
@@ -13,6 +14,16 @@ pub struct InstantiateMsg {
     pub nft_code_id: u64,
     /// Collection description, per SG-721 specs
     pub nft_info: CollectionInfo<RoyaltyInfoResponse>,
+    /// The fee rate charged for when creating or editing badges, quoted in ustars per byte
+    pub fee_per_byte: Decimal,
+}
+
+#[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
+pub enum SudoMsg {
+    /// Set the fee rate for creating or editing badges. Callable by L1 governance.
+    SetFeeRate {
+        fee_per_byte: Decimal,
+    }
 }
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
@@ -137,8 +148,12 @@ pub enum QueryMsg {
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
 pub struct ConfigResponse {
+    /// Address of the contract's developer
+    pub developer: String,
     /// Address of the Badge NFT contract
     pub nft: String,
     /// The total number of badges
     pub badge_count: u64,
+    /// The fee rate charged for when creating or editing badges, quoted in ustars per byte
+    pub fee_per_byte: Decimal,
 }


### PR DESCRIPTION
* `create_badge`, `edit_badge`, `add_keys` now require a fee
* the fee is split between the developer, the fair burn pool, and burned according to SG-1
* the fees are charged on a per-byte basis
* the fee rate (ustars per byte) is configurable by the L1 governance through the "sudo" entry point